### PR TITLE
Resolve browser security issue (Non SSL connectivity blocked)

### DIFF
--- a/public/js/device.js
+++ b/public/js/device.js
@@ -22,7 +22,9 @@
 	var clientId;
     var password;
     var useSSL = true;
-    var mqttPort = 8883;
+    var mqttPort = 1883;
+    var mqttPortSecure = 8883;
+    var deviceIdRegEx = /^([a-zA-Z0-9]){8,}$/;
 
 	var topic = "iot-2/evt/sensorData/fmt/json";
     var isConnected = false;
@@ -69,10 +71,17 @@
 	}
 
 	function getId() {
+
 		window.deviceId = prompt("Enter a unique ID of at least 8 characters containing only letters and numbers:");
-		if (window.deviceId) {
+		if (deviceIdRegEx.test(window.deviceId) === true) {
+			console.log("Connecting with device id: " + window.deviceId);
 			$("#deviceId").html(window.deviceId);
 			getDeviceCredentials();
+		}
+		else
+		{
+			window.alert("Device ID must be atleast 8 characters in length, and contain only letters and numbers.");
+			getId();
 		}
 	}
 
@@ -148,7 +157,7 @@
 				clientId = "d:"+orgId+":"+response.deviceType+":"+response.deviceId;
 				password = response.token;
 
-				client = new Paho.MQTT.Client(orgId+".messaging.internetofthings.ibmcloud.com", mqttPort, clientId);
+				client = new Paho.MQTT.Client(orgId+".messaging.internetofthings.ibmcloud.com", useSSL ? mqttPortSecure : mqttPort, clientId);
 
 				console.log("Attempting connect");
 

--- a/public/js/device.js
+++ b/public/js/device.js
@@ -21,6 +21,7 @@
 	var clientId;
     var password;
     var useSSL = true;
+    var mqttPort 8883;
 
 	var topic = "iot-2/evt/sensorData/fmt/json";
     var isConnected = false;
@@ -146,7 +147,7 @@
 				clientId = "d:"+orgId+":"+response.deviceType+":"+response.deviceId;
 				password = response.token;
 
-				client = new Paho.MQTT.Client(orgId+".messaging.internetofthings.ibmcloud.com", 1883, clientId);
+				client = new Paho.MQTT.Client(orgId+".messaging.internetofthings.ibmcloud.com", mqttPort, clientId);
 
 				console.log("Attempting connect");
 

--- a/public/js/device.js
+++ b/public/js/device.js
@@ -20,6 +20,7 @@
     var orgId;
 	var clientId;
     var password;
+    var useSSL = true;
 
 	var topic = "iot-2/evt/sensorData/fmt/json";
     var isConnected = false;
@@ -129,7 +130,8 @@
 			onSuccess: onConnectSuccess,
 			onFailure: onConnectFailure,
 			userName: "use-token-auth",
-			password: password
+			password: password,
+			useSSL: useSSL
 		});
     }
 

--- a/public/js/device.js
+++ b/public/js/device.js
@@ -12,6 +12,7 @@
  *
  * Contributors:
  *   Bryan Boyd - Initial implementation
+ *	 Alan Blyth - Modified to favour SSL over port 8883
  *******************************************************************************/
 (function(window){
     var ax = 0, ay = 0, az = 0, oa = 0, ob = 0, og = 0;

--- a/public/js/device.js
+++ b/public/js/device.js
@@ -22,7 +22,7 @@
 	var clientId;
     var password;
     var useSSL = true;
-    var mqttPort 8883;
+    var mqttPort = 8883;
 
 	var topic = "iot-2/evt/sensorData/fmt/json";
     var isConnected = false;


### PR DESCRIPTION
During a European IoT training course we found that if the user specified "https://", the page would perpetually report "connecting", we found this was due to MQTT not enforcing SSL, I have made the change to use SSL, and port 8883.

I have tested deploying to my BlueMix and is working after my changes with both http and https, tested on FireFox/Mac and Safari/iPhone.