### PR TITLE
use default node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,5 @@
     "cloudant": "*",
     "mqtt": "*"
   },
-  "engines": {
-		"node": "0.10.26"
-  },
   "repository": {}
 }


### PR DESCRIPTION
```
   2017-12-11T22:02:26.09-0600 [APP/PROC/WEB/0] ERR /home/vcap/app/node_modules/cloudant/cloudant.js:45
   2017-12-11T22:02:26.09-0600 [APP/PROC/WEB/0] ERR       'User-Agent': `nodejs-cloudant/${pkg.version} (Node.js ```
${process.version
   2017-12-11T22:02:26.09-0600 [APP/PROC/WEB/0] ERR                     ^
   2017-12-11T22:02:26.09-0600 [APP/PROC/WEB/0] ERR SyntaxError: Unexpected token ILLEGAL
```